### PR TITLE
fix man entry for is.memoised

### DIFF
--- a/R/memoise.R
+++ b/R/memoise.R
@@ -231,7 +231,7 @@ forget <- function(f) {
 
 #' Test whether a function is a memoised copy.
 #' Memoised copies of functions carry an attribute
-#' \code{memoised = TRUE}, which is.memoised() tests for.
+#' \code{memoised = TRUE}, which is what \code{is.memoised()} tests for.
 #' @param f Function to test.
 #' @seealso \code{\link{memoise}}, \code{\link{forget}}
 #' @export is.memoised is.memoized

--- a/man/is.memoised.Rd
+++ b/man/is.memoised.Rd
@@ -5,7 +5,7 @@
 \alias{is.memoized}
 \title{Test whether a function is a memoised copy.
 Memoised copies of functions carry an attribute
-\code{memoised = TRUE}, which is.memoised() tests for.}
+\code{memoised = TRUE}, which is what \code{is.memoised()} tests for.}
 \usage{
 is.memoised(f)
 }
@@ -15,7 +15,7 @@ is.memoised(f)
 \description{
 Test whether a function is a memoised copy.
 Memoised copies of functions carry an attribute
-\code{memoised = TRUE}, which is.memoised() tests for.
+\code{memoised = TRUE}, which is what \code{is.memoised()} tests for.
 }
 \examples{
 mem_lm <- memoise(lm)


### PR DESCRIPTION
Note also that the variable [`format.name` on line#184](https://github.com/r-lib/memoise/blob/master/R/memoise.R#L184) is not actually used and should be removed