### PR TITLE
Improve caching with different source files

### DIFF
--- a/R/memoise.R
+++ b/R/memoise.R
@@ -123,7 +123,7 @@ memoise <- memoize <- function(f, ..., envir = environment(f), cache = cache_mem
               lapply(default_args, eval, envir = environment()))
 
     hash <- encl$`_cache`$digest(
-      c(body(encl$`_f`), args,
+      c(as.character(body(encl$`_f`)), args,
         lapply(encl$`_additional`, function(x) eval(x[[2L]], environment(x))))
     )
 


### PR DESCRIPTION
`body(some_function)` returns the function's `srcref`, which will differ across computers.  When this is hashed, it will be different, which will prevent `cache_filesystem` from using caches created on different computers. Using `as.character(body(some_function))` hashes the contents of the function, but not the source file.

See also: `digest::sha1`
https://cran.r-project.org/web/packages/digest/vignettes/sha1.html

Fixes #58