### PR TITLE
Docs changes to has_cache

### DIFF
--- a/R/memoise.R
+++ b/R/memoise.R
@@ -246,7 +246,8 @@ is.memoised <- is.memoized <- function(f) {
 
 #' Test whether a memoised function has been cached for particular arguments.
 #' @param f Function to test.
-#' @param ... arguments to function.
+#' @return A function, with the same arguments as \code{f}, that can be called to test
+#'   if \code{f} has cached results.
 #' @seealso \code{\link{is.memoised}}, \code{\link{memoise}}
 #' @export
 #' @examples
@@ -254,7 +255,7 @@ is.memoised <- is.memoized <- function(f) {
 #' has_cache(mem_sum)(1, 2, 3) # FALSE
 #' mem_sum(1, 2, 3)
 #' has_cache(mem_sum)(1, 2, 3) # TRUE
-has_cache <- function(f, ...) {
+has_cache <- function(f) {
   if(!is.memoised(f)) stop("`f` is not a memoised function!", call. = FALSE)
 
   # Modify the function body of the function to simply return TRUE and FALSE

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ is.memoised(f)  # FALSE
 # Installation
 
 ```
-devtools::install_github("hadley/memoise")
+devtools::install_github("r-lib/memoise")
 ```
 
 # External Caches

--- a/man/has_cache.Rd
+++ b/man/has_cache.Rd
@@ -4,12 +4,14 @@
 \alias{has_cache}
 \title{Test whether a memoised function has been cached for particular arguments.}
 \usage{
-has_cache(f, ...)
+has_cache(f)
 }
 \arguments{
 \item{f}{Function to test.}
-
-\item{...}{arguments to function.}
+}
+\value{
+A function, with the same arguments as \code{f}, that can be called to test
+  if \code{f} has cached results.
 }
 \description{
 Test whether a memoised function has been cached for particular arguments.


### PR DESCRIPTION
As far as I could tell, the `...` argument of `has_cache` wasn't used.  Is that right?
(I've removed it and the tests still pass, but please let me know if I'm wrong.)

Sorry about the messy commit history.  Let me know if you want me to clean it up.