### PR TITLE
Add compression option for non-memory caches

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,4 @@ Suggests:
     covr,
     googleCloudStorageR
 License: MIT + file LICENSE
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * Name clashes between function arguments and variables defined when memoising
   no longer occur (#43, @egnha).
 * Add Google Cloud Storage support via `cache_gcs()` (#59 - @MarkEdmondson1234)
+* Add `compress` option for non-memory caches (#71 - @coolbutuseless)
 
 # Version 1.1.0
 * Caches now hash the function body along with the arguments, to ensure

--- a/R/cache_filesystem.R
+++ b/R/cache_filesystem.R
@@ -25,7 +25,7 @@
 #'
 #' @export
 #' @inheritParams cache_memory
-cache_filesystem <- function(path, algo = "xxhash64", compress=FALSE) {
+cache_filesystem <- function(path, algo = "xxhash64", compress = FALSE) {
 
   if (!dir.exists(path)) {
     dir.create(path, showWarnings = FALSE)
@@ -37,7 +37,7 @@ cache_filesystem <- function(path, algo = "xxhash64", compress=FALSE) {
   }
 
   cache_set <- function(key, value) {
-    saveRDS(value, file = file.path(path, key), compress=compress)
+    saveRDS(value, file = file.path(path, key), compress = compress)
   }
 
   cache_get <- function(key) {

--- a/R/cache_filesystem.R
+++ b/R/cache_filesystem.R
@@ -3,6 +3,8 @@
 #' Use a cache on the local filesystem that will persist between R sessions.
 #'
 #' @param path Directory in which to store cached items.
+#' @param compress Argument passed to \code{readRDS}. One of FALSE, "gzip",
+#' "bzip2" or "xz". Default: FALSE.
 #'
 #' @examples
 #'
@@ -23,7 +25,7 @@
 #'
 #' @export
 #' @inheritParams cache_memory
-cache_filesystem <- function(path, algo = "xxhash64") {
+cache_filesystem <- function(path, algo = "xxhash64", compress=FALSE) {
 
   if (!dir.exists(path)) {
     dir.create(path, showWarnings = FALSE)
@@ -35,7 +37,7 @@ cache_filesystem <- function(path, algo = "xxhash64") {
   }
 
   cache_set <- function(key, value) {
-    saveRDS(value, file = file.path(path, key))
+    saveRDS(value, file = file.path(path, key), compress=compress)
   }
 
   cache_get <- function(key) {

--- a/R/cache_filesystem.R
+++ b/R/cache_filesystem.R
@@ -3,7 +3,7 @@
 #' Use a cache on the local filesystem that will persist between R sessions.
 #'
 #' @param path Directory in which to store cached items.
-#' @param compress Argument passed to \code{readRDS}. One of FALSE, "gzip",
+#' @param compress Argument passed to \code{saveRDS}. One of FALSE, "gzip",
 #' "bzip2" or "xz". Default: FALSE.
 #'
 #' @examples

--- a/R/cache_gcs.R
+++ b/R/cache_gcs.R
@@ -20,7 +20,7 @@
 #' @inheritParams cache_memory
 #' @export
 cache_gcs <- function(cache_name = googleCloudStorageR::gcs_get_global_bucket(),
-                      algo = "sha512", compress=FALSE) {
+                      algo = "sha512", compress = FALSE) {
 
   if (!(requireNamespace("googleCloudStorageR"))) { stop("Package `googleCloudStorageR` must be installed for `cache_gcs()`.") } # nocov
 
@@ -35,7 +35,7 @@ cache_gcs <- function(cache_name = googleCloudStorageR::gcs_get_global_bucket(),
   cache_set <- function(key, value) {
     temp_file <- file.path(path, key)
     on.exit(unlink(temp_file))
-    saveRDS(value, file = temp_file, compress=compress)
+    saveRDS(value, file = temp_file, compress = compress)
     suppressMessages(
       googleCloudStorageR::gcs_upload(temp_file, name = key, bucket = cache_name)
     )

--- a/R/cache_gcs.R
+++ b/R/cache_gcs.R
@@ -15,10 +15,12 @@
 #'
 #'
 #' @param cache_name Bucket name for storing cache files.
+#' @param compress Argument passed to \code{readRDS}. One of FALSE, "gzip",
+#' "bzip2" or "xz". Default: FALSE.
 #' @inheritParams cache_memory
 #' @export
 cache_gcs <- function(cache_name = googleCloudStorageR::gcs_get_global_bucket(),
-                      algo = "sha512") {
+                      algo = "sha512", compress=FALSE) {
 
   if (!(requireNamespace("googleCloudStorageR"))) { stop("Package `googleCloudStorageR` must be installed for `cache_gcs()`.") } # nocov
 
@@ -33,7 +35,7 @@ cache_gcs <- function(cache_name = googleCloudStorageR::gcs_get_global_bucket(),
   cache_set <- function(key, value) {
     temp_file <- file.path(path, key)
     on.exit(unlink(temp_file))
-    saveRDS(value, file = temp_file)
+    saveRDS(value, file = temp_file, compress=compress)
     suppressMessages(
       googleCloudStorageR::gcs_upload(temp_file, name = key, bucket = cache_name)
     )

--- a/R/cache_gcs.R
+++ b/R/cache_gcs.R
@@ -15,7 +15,7 @@
 #'
 #'
 #' @param cache_name Bucket name for storing cache files.
-#' @param compress Argument passed to \code{readRDS}. One of FALSE, "gzip",
+#' @param compress Argument passed to \code{saveRDS}. One of FALSE, "gzip",
 #' "bzip2" or "xz". Default: FALSE.
 #' @inheritParams cache_memory
 #' @export

--- a/R/cache_s3.R
+++ b/R/cache_s3.R
@@ -15,10 +15,12 @@
 #'
 #'
 #' @param cache_name Bucket name for storing cache files.
+#' @param compress Argument passed to \code{readRDS}. One of FALSE, "gzip",
+#' "bzip2" or "xz". Default: FALSE.
 #' @inheritParams cache_memory
 #' @export
 
-cache_s3 <- function(cache_name, algo = "sha512") {
+cache_s3 <- function(cache_name, algo = "sha512", compress=FALSE) {
 
   if (!(requireNamespace("aws.s3"))) { stop("Package `aws.s3` must be installed for `cache_s3()`.") } # nocov
 
@@ -37,7 +39,7 @@ cache_s3 <- function(cache_name, algo = "sha512") {
   cache_set <- function(key, value) {
     temp_file <- file.path(path, key)
     on.exit(unlink(temp_file))
-    saveRDS(value, file = temp_file)
+    saveRDS(value, file = temp_file, compress=compress)
     aws.s3::put_object(temp_file, object = key, bucket = cache_name)
   }
 

--- a/R/cache_s3.R
+++ b/R/cache_s3.R
@@ -20,7 +20,7 @@
 #' @inheritParams cache_memory
 #' @export
 
-cache_s3 <- function(cache_name, algo = "sha512", compress=FALSE) {
+cache_s3 <- function(cache_name, algo = "sha512", compress = FALSE) {
 
   if (!(requireNamespace("aws.s3"))) { stop("Package `aws.s3` must be installed for `cache_s3()`.") } # nocov
 
@@ -39,7 +39,7 @@ cache_s3 <- function(cache_name, algo = "sha512", compress=FALSE) {
   cache_set <- function(key, value) {
     temp_file <- file.path(path, key)
     on.exit(unlink(temp_file))
-    saveRDS(value, file = temp_file, compress=compress)
+    saveRDS(value, file = temp_file, compress = compress)
     aws.s3::put_object(temp_file, object = key, bucket = cache_name)
   }
 

--- a/R/cache_s3.R
+++ b/R/cache_s3.R
@@ -15,7 +15,7 @@
 #'
 #'
 #' @param cache_name Bucket name for storing cache files.
-#' @param compress Argument passed to \code{readRDS}. One of FALSE, "gzip",
+#' @param compress Argument passed to \code{saveRDS}. One of FALSE, "gzip",
 #' "bzip2" or "xz". Default: FALSE.
 #' @inheritParams cache_memory
 #' @export

--- a/man/cache_filesystem.Rd
+++ b/man/cache_filesystem.Rd
@@ -12,7 +12,7 @@ cache_filesystem(path, algo = "xxhash64", compress = FALSE)
 \item{algo}{The hashing algorithm used for the cache, see
 \code{\link[digest]{digest}} for available algorithms.}
 
-\item{compress}{Argument passed to \code{readRDS}. One of FALSE, "gzip",
+\item{compress}{Argument passed to \code{saveRDS}. One of FALSE, "gzip",
 "bzip2" or "xz". Default: FALSE.}
 }
 \description{

--- a/man/cache_filesystem.Rd
+++ b/man/cache_filesystem.Rd
@@ -4,13 +4,16 @@
 \alias{cache_filesystem}
 \title{Filesystem Cache}
 \usage{
-cache_filesystem(path, algo = "xxhash64")
+cache_filesystem(path, algo = "xxhash64", compress = FALSE)
 }
 \arguments{
 \item{path}{Directory in which to store cached items.}
 
 \item{algo}{The hashing algorithm used for the cache, see
 \code{\link[digest]{digest}} for available algorithms.}
+
+\item{compress}{Argument passed to \code{readRDS}. One of FALSE, "gzip",
+"bzip2" or "xz". Default: FALSE.}
 }
 \description{
 Use a cache on the local filesystem that will persist between R sessions.

--- a/man/cache_gcs.Rd
+++ b/man/cache_gcs.Rd
@@ -6,13 +6,16 @@
 Google Cloud Storage backed cache, for remote caching.}
 \usage{
 cache_gcs(cache_name = googleCloudStorageR::gcs_get_global_bucket(),
-  algo = "sha512")
+  algo = "sha512", compress = FALSE)
 }
 \arguments{
 \item{cache_name}{Bucket name for storing cache files.}
 
 \item{algo}{The hashing algorithm used for the cache, see
 \code{\link[digest]{digest}} for available algorithms.}
+
+\item{compress}{Argument passed to \code{readRDS}. One of FALSE, "gzip",
+"bzip2" or "xz". Default: FALSE.}
 }
 \description{
 Google Cloud Storage Cache

--- a/man/cache_gcs.Rd
+++ b/man/cache_gcs.Rd
@@ -14,7 +14,7 @@ cache_gcs(cache_name = googleCloudStorageR::gcs_get_global_bucket(),
 \item{algo}{The hashing algorithm used for the cache, see
 \code{\link[digest]{digest}} for available algorithms.}
 
-\item{compress}{Argument passed to \code{readRDS}. One of FALSE, "gzip",
+\item{compress}{Argument passed to \code{saveRDS}. One of FALSE, "gzip",
 "bzip2" or "xz". Default: FALSE.}
 }
 \description{

--- a/man/cache_s3.Rd
+++ b/man/cache_s3.Rd
@@ -13,7 +13,7 @@ cache_s3(cache_name, algo = "sha512", compress = FALSE)
 \item{algo}{The hashing algorithm used for the cache, see
 \code{\link[digest]{digest}} for available algorithms.}
 
-\item{compress}{Argument passed to \code{readRDS}. One of FALSE, "gzip",
+\item{compress}{Argument passed to \code{saveRDS}. One of FALSE, "gzip",
 "bzip2" or "xz". Default: FALSE.}
 }
 \description{

--- a/man/cache_s3.Rd
+++ b/man/cache_s3.Rd
@@ -5,13 +5,16 @@
 \title{Amazon Web Services S3 Cache
 Amazon Web Services S3 backed cache, for remote caching.}
 \usage{
-cache_s3(cache_name, algo = "sha512")
+cache_s3(cache_name, algo = "sha512", compress = FALSE)
 }
 \arguments{
 \item{cache_name}{Bucket name for storing cache files.}
 
 \item{algo}{The hashing algorithm used for the cache, see
 \code{\link[digest]{digest}} for available algorithms.}
+
+\item{compress}{Argument passed to \code{readRDS}. One of FALSE, "gzip",
+"bzip2" or "xz". Default: FALSE.}
 }
 \description{
 Amazon Web Services S3 Cache


### PR DESCRIPTION
Allow the filesystem, GCS and S3 caches to compress objects before saving to disk or over the network.