### PR TITLE
doc for avoid build-time dependency #76

### DIFF
--- a/R/memoise.R
+++ b/R/memoise.R
@@ -36,7 +36,7 @@
 #' but when the package is loaded. The simplest way to do this is within
 #' \code{.onLoad()} with, for example
 #'
-#' \code{
+#'
 #' \preformatted{
 #' # file.R
 #' fun <- function() {
@@ -48,7 +48,6 @@
 #'  fun <<- memoise::memoise(fun)
 #' }
 #' }
-#'}
 #' @name memoise
 #' @title Memoise a function.
 #' @param f     Function of which to create a memoised copy.

--- a/R/memoise.R
+++ b/R/memoise.R
@@ -32,6 +32,24 @@
 #'     repeated.
 #' }
 #'
+#' It is recommended that functions in a package are not memoised at build-time,
+#' but when the package is loaded. The simplest way to do this is within
+#' \code{.onLoad()} with, for example
+#'
+#' \cr
+#' \code{
+#' # file.R
+#' \cr
+#' fun <- function() { \cr
+#'  some_expensive_process() \cr
+#' } \cr
+#' \cr
+#' # zzz.R
+#' \cr .onLoad <- function(pkgname, libname) { \cr
+#'  fun <<- memoise::memoise(fun) \cr
+#' } \cr
+#' }
+#'
 #' @name memoise
 #' @title Memoise a function.
 #' @param f     Function of which to create a memoised copy.

--- a/R/memoise.R
+++ b/R/memoise.R
@@ -36,20 +36,19 @@
 #' but when the package is loaded. The simplest way to do this is within
 #' \code{.onLoad()} with, for example
 #'
-#' \cr
 #' \code{
+#' \preformatted{
 #' # file.R
-#' \cr
-#' fun <- function() { \cr
-#'  some_expensive_process() \cr
-#' } \cr
-#' \cr
-#' # zzz.R
-#' \cr .onLoad <- function(pkgname, libname) { \cr
-#'  fun <<- memoise::memoise(fun) \cr
-#' } \cr
+#' fun <- function() {
+#'  some_expensive_process()
 #' }
 #'
+#' # zzz.R
+#' .onLoad <- function(pkgname, libname) {
+#'  fun <<- memoise::memoise(fun)
+#' }
+#' }
+#'}
 #' @name memoise
 #' @title Memoise a function.
 #' @param f     Function of which to create a memoised copy.

--- a/man/memoise.Rd
+++ b/man/memoise.Rd
@@ -57,7 +57,6 @@ It is recommended that functions in a package are not memoised at build-time,
 but when the package is loaded. The simplest way to do this is within
 \code{.onLoad()} with, for example
 
-\code{
 \preformatted{
 # file.R
 fun <- function() {
@@ -67,7 +66,6 @@ fun <- function() {
 # zzz.R
 .onLoad <- function(pkgname, libname) {
  fun <<- memoise::memoise(fun)
-}
 }
 }
 }

--- a/man/memoise.Rd
+++ b/man/memoise.Rd
@@ -52,6 +52,24 @@ Two example situations where \code{memoise} could be of use:
     once at the R prompt, or put it somewhere else where it won't get
     repeated.
 }
+
+It is recommended that functions in a package are not memoised at build-time,
+but when the package is loaded. The simplest way to do this is within
+\code{.onLoad()} with, for example
+
+\cr
+\code{
+# file.R
+\cr
+fun <- function() { \cr
+ some_expensive_process() \cr
+} \cr
+\cr
+# zzz.R
+\cr .onLoad <- function(pkgname, libname) { \cr
+ fun <<- memoise::memoise(fun) \cr
+} \cr
+}
 }
 \examples{
 # a() is evaluated anew each time. memA() is only re-evaluated

--- a/man/memoise.Rd
+++ b/man/memoise.Rd
@@ -57,18 +57,18 @@ It is recommended that functions in a package are not memoised at build-time,
 but when the package is loaded. The simplest way to do this is within
 \code{.onLoad()} with, for example
 
-\cr
 \code{
+\preformatted{
 # file.R
-\cr
-fun <- function() { \cr
- some_expensive_process() \cr
-} \cr
-\cr
+fun <- function() {
+ some_expensive_process()
+}
+
 # zzz.R
-\cr .onLoad <- function(pkgname, libname) { \cr
- fun <<- memoise::memoise(fun) \cr
-} \cr
+.onLoad <- function(pkgname, libname) {
+ fun <<- memoise::memoise(fun)
+}
+}
 }
 }
 \examples{


### PR DESCRIPTION
Short documentation addition to use on-load function replacements in `.onLoad()` as per #76 