### PR TITLE
suppress 404 messages from aws.s3::head_object for new keys in cache_s3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 directory after using relative path (#51, #65 - @xhdong-umd)
 * Add `drop_cache()` to drop the cached result for particular arguments (#78 -
   richardkunze)
+* Suppress messages of `aws.s3::head_object` within `cache_s3`'s `cache_has_key`
+  to avoid printing of 404 messages for new keys (#96, @stelsemeyer).
 
 # Version 1.1.0
 * Caches now hash the function body along with the arguments, to ensure

--- a/R/cache_s3.R
+++ b/R/cache_s3.R
@@ -52,7 +52,7 @@ cache_s3 <- function(cache_name, algo = "sha512", compress = FALSE) {
   }
 
   cache_has_key <- function(key) {
-    aws.s3::head_object(object = key, bucket = cache_name)
+    suppressMessages(aws.s3::head_object(object = key, bucket = cache_name))
   }
 
   cache_drop_key <- function(key) {


### PR DESCRIPTION
References [issue 96](https://github.com/r-lib/memoise/issues/96).