### PR TITLE
Fix .onLoad argument order

### DIFF
--- a/R/memoise.R
+++ b/R/memoise.R
@@ -44,7 +44,7 @@
 #' }
 #'
 #' # zzz.R
-#' .onLoad <- function(pkgname, libname) {
+#' .onLoad <- function(libname, pkgname) {
 #'  fun <<- memoise::memoise(fun)
 #' }
 #' }


### PR DESCRIPTION
The current docs suggest writing a call to `.onLoad` as `.onLoad(pkgname, libname)` but this is out of order. `devtools::check` will throw the following error:

>  Package startup functions should have two arguments with names starting
    with ‘lib’ and ‘pkg’, respectively.
  See section ‘Good practice’ in '?.onAttach'.
