### PR TITLE
More lenient check for is_old_cache()

### DIFF
--- a/R/old_cache.R
+++ b/R/old_cache.R
@@ -25,10 +25,8 @@ wrap_old_cache <- function(x) {
 
 # Returns TRUE if it's an old-style cache.
 is_old_cache <- function(x) {
-  is.function(x$reset) &&
-    is.function(x$digest) &&
+  is.function(x$digest) &&
     is.function(x$set) &&
     is.function(x$get) &&
-    is.function(x$has_key) &&
-    is.function(x$drop_key)
+    is.function(x$has_key)
 }


### PR DESCRIPTION
Closes #117. This makes `is_old_cache()` more lenient, so that it doesn't check for a `$reset()` or `$drop_key()` method. It now only looks for the methods that are essential for `memoise()` to work. (The methods removed in this PR are only used in the `forget()` and `drop_cache()` functions.)