### PR TITLE
link to `drop_cache()` more often in documentation

### DIFF
--- a/R/memoise.R
+++ b/R/memoise.R
@@ -61,7 +61,8 @@
 #'   which is used as a cache key.
 #' @param omit_args Names of arguments to ignore when calculating hash.
 #' @seealso \code{\link{forget}}, \code{\link{is.memoised}},
-#'   \code{\link{timeout}}, \url{https://en.wikipedia.org/wiki/Memoization}
+#'   \code{\link{timeout}}, \url{https://en.wikipedia.org/wiki/Memoization},
+#'   \code{\link{drop_cache}}
 #' @aliases memoise memoize
 #' @export memoise memoize
 #' @examples
@@ -255,11 +256,12 @@ print.memoised <- function(x, ...) {
 }
 
 #' Forget past results.
-#' Resets the cache of a memoised function.
+#' Resets the cache of a memoised function. Use \code{\link{drop_cache}} to
+#' reset the cache only for particular arguments.
 #'
 #' @param f memoised function
 #' @export
-#' @seealso \code{\link{memoise}}, \code{\link{is.memoised}}
+#' @seealso \code{\link{memoise}}, \code{\link{is.memoised}}, \code{\link{drop_cache}}
 #' @examples
 #' memX <- memoise(function() { Sys.sleep(1); runif(1) })
 #' # The forget() function
@@ -300,7 +302,7 @@ is.memoised <- is.memoized <- function(f) {
 #' @param f Function to test.
 #' @return A function, with the same arguments as \code{f}, that can be called to test
 #'   if \code{f} has cached results.
-#' @seealso \code{\link{is.memoised}}, \code{\link{memoise}}
+#' @seealso \code{\link{is.memoised}}, \code{\link{memoise}}, \code{\link{drop_cache}}
 #' @export
 #' @examples
 #' mem_sum <- memoise(sum)

--- a/man/forget.Rd
+++ b/man/forget.Rd
@@ -3,7 +3,8 @@
 \name{forget}
 \alias{forget}
 \title{Forget past results.
-Resets the cache of a memoised function.}
+Resets the cache of a memoised function. Use \code{\link{drop_cache}} to
+reset the cache only for particular arguments.}
 \usage{
 forget(f)
 }
@@ -12,7 +13,8 @@ forget(f)
 }
 \description{
 Forget past results.
-Resets the cache of a memoised function.
+Resets the cache of a memoised function. Use \code{\link{drop_cache}} to
+reset the cache only for particular arguments.
 }
 \examples{
 memX <- memoise(function() { Sys.sleep(1); runif(1) })
@@ -23,5 +25,5 @@ forget(memX)
 system.time(print(memX()))
 }
 \seealso{
-\code{\link{memoise}}, \code{\link{is.memoised}}
+\code{\link{memoise}}, \code{\link{is.memoised}}, \code{\link{drop_cache}}
 }

--- a/man/has_cache.Rd
+++ b/man/has_cache.Rd
@@ -23,5 +23,5 @@ mem_sum(1, 2, 3)
 has_cache(mem_sum)(1, 2, 3) # TRUE
 }
 \seealso{
-\code{\link{is.memoised}}, \code{\link{memoise}}
+\code{\link{is.memoised}}, \code{\link{memoise}}, \code{\link{drop_cache}}
 }

--- a/man/memoise.Rd
+++ b/man/memoise.Rd
@@ -141,5 +141,6 @@ memA3(2)
 }
 \seealso{
 \code{\link{forget}}, \code{\link{is.memoised}},
-  \code{\link{timeout}}, \url{https://en.wikipedia.org/wiki/Memoization}
+  \code{\link{timeout}}, \url{https://en.wikipedia.org/wiki/Memoization},
+  \code{\link{drop_cache}}
 }


### PR DESCRIPTION
fixes #125 