### PR TITLE
Apply `omit_args` also to default arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # memoise (development version)
 
+* `omit_args` now also works for default arguments (@mgirlich, #145).
+
 # memoise 2.0.1
 
 # Version 2.0.0.9000

--- a/R/memoise.R
+++ b/R/memoise.R
@@ -148,12 +148,12 @@ memoise <- memoize <- function(
     # That has not been called
     default_args <- default_args[setdiff(names(default_args), names(called_args))]
 
-    # Ignored specified arguments when hashing
-    called_args[encl$`_omit_args`] <- NULL
-
     # Evaluate all the arguments
     args <- c(lapply(called_args, eval, parent.frame()),
               lapply(default_args, eval, envir = environment()))
+
+    # Ignored specified arguments when hashing
+    args[encl$`_omit_args`] <- NULL
 
     key <- encl$`_hash`(
       c(

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -327,19 +327,28 @@ test_that("omit_args respected", {
 
   expect_true(identical(res1, res2))
 
-  # Also works for default args
-  f <- function(n, x = rnorm(1)) {
-    rnorm(n)
+  # Also works for default arguments
+  a <- 0
+  f <- function(x = a) {
+    a <<- a + 1
+    a
   }
-  mem_f <- memoise(f)
-  expect_false(identical(res1, res2))
-  res1 <- mem_f(1)
-  res2 <- mem_f(1)
 
+  # everytime `f()` is called its value increases by 1
+  expect_equal(f(), 1)
+  expect_equal(f(), 2)
+
+  # it still increases by one when memoised as the argument `x` changes
+  a <- 0
+  mem_f <- memoise::memoise(f)
+  expect_equal(mem_f(), 1)
+  expect_equal(mem_f(), 2)
+
+  # but `x` can be ignored via `omit_args`
+  a <- 0
   mem_f2 <- memoise(f, omit_args = "x")
-  res1 <- mem_f2(1)
-  res2 <- mem_f2(1)
-  expect_true(identical(res1, res2))
+  expect_equal(mem_f2(), 1)
+  expect_equal(mem_f2(), 1)
 })
 
 context("has_cache")

--- a/tests/testthat/test-memoise.R
+++ b/tests/testthat/test-memoise.R
@@ -326,6 +326,20 @@ test_that("omit_args respected", {
   res2 <- mem_rnorm(10, mean = +100)
 
   expect_true(identical(res1, res2))
+
+  # Also works for default args
+  f <- function(n, x = rnorm(1)) {
+    rnorm(n)
+  }
+  mem_f <- memoise(f)
+  expect_false(identical(res1, res2))
+  res1 <- mem_f(1)
+  res2 <- mem_f(1)
+
+  mem_f2 <- memoise(f, omit_args = "x")
+  res1 <- mem_f2(1)
+  res2 <- mem_f2(1)
+  expect_true(identical(res1, res2))
 })
 
 context("has_cache")


### PR DESCRIPTION
Fixes #145.